### PR TITLE
Remove max index

### DIFF
--- a/src/HaskellWorks/Data/BalancedParens/RangeMinMax.hs
+++ b/src/HaskellWorks/Data/BalancedParens/RangeMinMax.hs
@@ -41,13 +41,10 @@ import qualified Data.Vector.Storable as DVS
 data RangeMinMax a = RangeMinMax
   { rangeMinMaxBP       :: !a
   , rangeMinMaxL0Min    :: !(DVS.Vector Int8)
-  , rangeMinMaxL0Max    :: !(DVS.Vector Int8)
   , rangeMinMaxL0Excess :: !(DVS.Vector Int8)
   , rangeMinMaxL1Min    :: !(DVS.Vector Int16)
-  , rangeMinMaxL1Max    :: !(DVS.Vector Int16)
   , rangeMinMaxL1Excess :: !(DVS.Vector Int16)
   , rangeMinMaxL2Min    :: !(DVS.Vector Int16)
-  , rangeMinMaxL2Max    :: !(DVS.Vector Int16)
   , rangeMinMaxL2Excess :: !(DVS.Vector Int16)
   } deriving (NFData, Generic)
 
@@ -79,13 +76,10 @@ mkRangeMinMax :: AsVector64 a => a -> RangeMinMax a
 mkRangeMinMax bp = RangeMinMax
   { rangeMinMaxBP       = bp
   , rangeMinMaxL0Min    = rmmL0Min
-  , rangeMinMaxL0Max    = rmmL0Max
   , rangeMinMaxL0Excess = dvsReword rmmL0Excess
   , rangeMinMaxL1Min    = rmmL1Min
-  , rangeMinMaxL1Max    = rmmL1Max
   , rangeMinMaxL1Excess = dvsReword rmmL1Excess
   , rangeMinMaxL2Min    = rmmL2Min
-  , rangeMinMaxL2Max    = rmmL2Max
   , rangeMinMaxL2Excess = rmmL2Excess
   }
   where bpv           = asVector64 bp
@@ -103,9 +97,6 @@ mkRangeMinMax bp = RangeMinMax
         rmmL0Min      = dvsConstructNI lenL0 (\i -> let Triplet minE _ _ = allMinMaxL0 DVS.! i in fromIntegral minE)
         rmmL1Min      = dvsConstructNI lenL1 (\i -> let Triplet minE _ _ = allMinMaxL1 DVS.! i in fromIntegral minE)
         rmmL2Min      = dvsConstructNI lenL2 (\i -> let Triplet minE _ _ = allMinMaxL2 DVS.! i in fromIntegral minE)
-        rmmL0Max      = dvsConstructNI lenL0 (\i -> let Triplet _ _ maxE = allMinMaxL0 DVS.! i in fromIntegral maxE)
-        rmmL1Max      = dvsConstructNI lenL1 (\i -> let Triplet _ _ maxE = allMinMaxL1 DVS.! i in fromIntegral maxE)
-        rmmL2Max      = dvsConstructNI lenL2 (\i -> let Triplet _ _ maxE = allMinMaxL2 DVS.! i in fromIntegral maxE)
 
 dropTake :: DVS.Storable a => Int -> Int -> DVS.Vector a -> DVS.Vector a
 dropTake n o = DVS.take o . DVS.drop n

--- a/src/HaskellWorks/Data/BalancedParens/RangeMinMax2.hs
+++ b/src/HaskellWorks/Data/BalancedParens/RangeMinMax2.hs
@@ -9,8 +9,6 @@
 module HaskellWorks.Data.BalancedParens.RangeMinMax2
   ( RangeMinMax2(..)
   , mkRangeMinMax2
-  , genMin
-  , genMax
   ) where
 
 import Control.DeepSeq
@@ -43,19 +41,14 @@ import qualified Data.Vector.Storable as DVS
 data RangeMinMax2 a = RangeMinMax2
   { rangeMinMax2BP       :: !a
   , rangeMinMax2L0Min    :: !(DVS.Vector Int8)
-  , rangeMinMax2L0Max    :: !(DVS.Vector Int8)
   , rangeMinMax2L0Excess :: !(DVS.Vector Int8)
   , rangeMinMax2L1Min    :: !(DVS.Vector Int16)
-  , rangeMinMax2L1Max    :: !(DVS.Vector Int16)
   , rangeMinMax2L1Excess :: !(DVS.Vector Int16)
   , rangeMinMax2L2Min    :: !(DVS.Vector Int16)
-  , rangeMinMax2L2Max    :: !(DVS.Vector Int16)
   , rangeMinMax2L2Excess :: !(DVS.Vector Int16)
   , rangeMinMax2L3Min    :: !(DVS.Vector Int16)
-  , rangeMinMax2L3Max    :: !(DVS.Vector Int16)
   , rangeMinMax2L3Excess :: !(DVS.Vector Int16)
   , rangeMinMax2L4Min    :: !(DVS.Vector Int16)
-  , rangeMinMax2L4Max    :: !(DVS.Vector Int16)
   , rangeMinMax2L4Excess :: !(DVS.Vector Int16)
   } deriving (NFData, Generic)
 
@@ -103,19 +96,14 @@ mkRangeMinMax2 :: AsVector64 a => a -> RangeMinMax2 a
 mkRangeMinMax2 bp = RangeMinMax2
   { rangeMinMax2BP       = bp
   , rangeMinMax2L0Min    = dvsReword rmmL0Min
-  , rangeMinMax2L0Max    = dvsReword rmmL0Max
   , rangeMinMax2L0Excess = dvsReword rmmL0Excess
   , rangeMinMax2L1Min    = rmmL1Min
-  , rangeMinMax2L1Max    = rmmL1Max
   , rangeMinMax2L1Excess = rmmL1Excess
   , rangeMinMax2L2Min    = rmmL2Min
-  , rangeMinMax2L2Max    = rmmL2Max
   , rangeMinMax2L2Excess = rmmL2Excess
   , rangeMinMax2L3Min    = rmmL3Min
-  , rangeMinMax2L3Max    = rmmL3Max
   , rangeMinMax2L3Excess = rmmL3Excess
   , rangeMinMax2L4Min    = rmmL4Min
-  , rangeMinMax2L4Max    = rmmL4Max
   , rangeMinMax2L4Excess = rmmL4Excess
   }
   where bpv           = asVector64 bp
@@ -137,20 +125,10 @@ mkRangeMinMax2 bp = RangeMinMax2
         rmmL2Min      = dvsConstructNI lenL2 (\i -> genMin 0 (pageFill i factorL2 0 rmmL1Min) (pageFill i factorL2 0 rmmL1Excess))
         rmmL3Min      = dvsConstructNI lenL3 (\i -> genMin 0 (pageFill i factorL3 0 rmmL2Min) (pageFill i factorL3 0 rmmL2Excess))
         rmmL4Min      = dvsConstructNI lenL4 (\i -> genMin 0 (pageFill i factorL4 0 rmmL3Min) (pageFill i factorL4 0 rmmL3Excess))
-        rmmL0Max      = dvsConstructNI lenL0 (\i -> let Triplet _ _ maxE = allMinMaxL0 DV.! i in fromIntegral maxE) :: DVS.Vector Int16
-        rmmL1Max      = dvsConstructNI lenL1 (\i -> genMax 0 (pageFill i factorL1 0 rmmL0Max) (pageFill i factorL1 0 rmmL0Excess))
-        rmmL2Max      = dvsConstructNI lenL2 (\i -> genMax 0 (pageFill i factorL2 0 rmmL1Max) (pageFill i factorL2 0 rmmL1Excess))
-        rmmL3Max      = dvsConstructNI lenL3 (\i -> genMax 0 (pageFill i factorL3 0 rmmL2Max) (pageFill i factorL3 0 rmmL2Excess))
-        rmmL4Max      = dvsConstructNI lenL4 (\i -> genMax 0 (pageFill i factorL4 0 rmmL3Max) (pageFill i factorL4 0 rmmL3Excess))
 
 genMin :: (Integral a, DVS.Storable a) => a -> DVS.Vector a -> DVS.Vector a -> a
 genMin mL mins excesses = if not (DVS.null mins) || not (DVS.null excesses)
   then genMin (dvsLastOrZero mins `min` (mL + dvsLastOrZero excesses)) (DVS.init mins) (DVS.init excesses)
-  else mL
-
-genMax :: (Integral a, DVS.Storable a) => a -> DVS.Vector a -> DVS.Vector a -> a
-genMax mL maxs excesses = if not (DVS.null maxs) || not (DVS.null excesses)
-  then genMax (dvsLastOrZero maxs `max` (mL + dvsLastOrZero excesses)) (DVS.init maxs) (DVS.init excesses)
   else mL
 
 pageFill :: DVS.Storable a => Int -> Int -> a -> DVS.Vector a -> DVS.Vector a


### PR DESCRIPTION
```
benchmarking Vector/FindClose 2-bit/Broadword
time                 29.05 ns   (28.64 ns .. 29.57 ns)
                     0.998 R²   (0.998 R² .. 0.999 R²)
mean                 29.51 ns   (29.14 ns .. 29.96 ns)
std dev              1.406 ns   (1.092 ns .. 2.089 ns)
variance introduced by outliers: 71% (severely inflated)

benchmarking Vector/FindClose 2-bit/Naive
time                 11.98 ns   (11.80 ns .. 12.22 ns)
                     0.998 R²   (0.998 R² .. 0.999 R²)
mean                 12.16 ns   (11.99 ns .. 12.39 ns)
std dev              693.1 ps   (548.3 ps .. 1.041 ns)
variance introduced by outliers: 79% (severely inflated)

benchmarking Vector/FindClose 4-bit/Broadword
time                 29.30 ns   (28.97 ns .. 29.73 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 29.98 ns   (29.62 ns .. 30.40 ns)
std dev              1.367 ns   (1.089 ns .. 1.767 ns)
variance introduced by outliers: 69% (severely inflated)

benchmarking Vector/FindClose 4-bit/Naive
time                 15.35 ns   (15.15 ns .. 15.58 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 15.78 ns   (15.55 ns .. 16.02 ns)
std dev              821.0 ps   (695.0 ps .. 1.032 ns)
variance introduced by outliers: 75% (severely inflated)

benchmarking Vector/FindClose 8-bit/Broadword
time                 29.09 ns   (28.67 ns .. 29.58 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 29.89 ns   (29.50 ns .. 30.37 ns)
std dev              1.461 ns   (1.263 ns .. 1.757 ns)
variance introduced by outliers: 72% (severely inflated)

benchmarking Vector/FindClose 8-bit/Naive
time                 22.67 ns   (22.44 ns .. 22.89 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 22.92 ns   (22.62 ns .. 23.24 ns)
std dev              1.019 ns   (842.9 ps .. 1.324 ns)
variance introduced by outliers: 68% (severely inflated)

benchmarking Vector/FindClose 16-bit/Broadword
time                 29.07 ns   (28.67 ns .. 29.50 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 29.65 ns   (29.27 ns .. 30.06 ns)
std dev              1.313 ns   (1.129 ns .. 1.639 ns)
variance introduced by outliers: 67% (severely inflated)

benchmarking Vector/FindClose 16-bit/Naive
time                 37.76 ns   (37.33 ns .. 38.34 ns)
                     0.998 R²   (0.998 R² .. 0.999 R²)
mean                 38.37 ns   (37.83 ns .. 38.87 ns)
std dev              1.763 ns   (1.528 ns .. 2.084 ns)
variance introduced by outliers: 68% (severely inflated)

benchmarking Vector/FindClose 32-bit/Broadword
time                 29.06 ns   (28.74 ns .. 29.44 ns)
                     0.998 R²   (0.998 R² .. 0.999 R²)
mean                 29.65 ns   (29.21 ns .. 30.16 ns)
std dev              1.481 ns   (1.223 ns .. 1.844 ns)
variance introduced by outliers: 73% (severely inflated)

benchmarking Vector/FindClose 32-bit/Naive
time                 67.48 ns   (66.65 ns .. 68.44 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 68.97 ns   (68.11 ns .. 70.31 ns)
std dev              3.528 ns   (2.513 ns .. 5.874 ns)
variance introduced by outliers: 72% (severely inflated)

benchmarking Vector/FindClose 64-bit/Broadword
time                 29.44 ns   (29.13 ns .. 29.87 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 30.06 ns   (29.59 ns .. 30.61 ns)
std dev              1.632 ns   (1.351 ns .. 2.015 ns)
variance introduced by outliers: 76% (severely inflated)

benchmarking Vector/FindClose 64-bit/Naive
time                 132.7 ns   (130.9 ns .. 134.7 ns)
                     0.998 R²   (0.998 R² .. 0.999 R²)
mean                 134.2 ns   (132.6 ns .. 136.1 ns)
std dev              5.955 ns   (5.043 ns .. 7.459 ns)
variance introduced by outliers: 65% (severely inflated)

benchmarking Vector/Vanilla/findClose
time                 692.7 ms   (685.4 ms .. 698.3 ms)
                     1.000 R²   (NaN R² .. 1.000 R²)
mean                 710.9 ms   (702.5 ms .. 722.8 ms)
std dev              11.27 ms   (941.1 μs .. 14.20 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking Rmm/Vector64/mkRangeMinMax
time                 139.9 μs   (138.7 μs .. 141.7 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 143.0 μs   (141.0 μs .. 145.4 μs)
std dev              7.770 μs   (6.499 μs .. 9.610 μs)
variance introduced by outliers: 55% (severely inflated)

benchmarking Rmm/RangeMinMax/findClose
time                 6.504 ms   (6.379 ms .. 6.664 ms)
                     0.997 R²   (0.994 R² .. 0.998 R²)
mean                 6.694 ms   (6.620 ms .. 6.779 ms)
std dev              240.1 μs   (201.6 μs .. 294.3 μs)
variance introduced by outliers: 16% (moderately inflated)

benchmarking Rmm2/Vector64/mkRangeMinMax2
time                 3.252 ms   (3.198 ms .. 3.299 ms)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 3.288 ms   (3.261 ms .. 3.323 ms)
std dev              98.94 μs   (83.80 μs .. 114.7 μs)
variance introduced by outliers: 14% (moderately inflated)

benchmarking Rmm2/RangeMinMax2/findClose
time                 6.564 ms   (6.484 ms .. 6.656 ms)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 6.571 ms   (6.499 ms .. 6.632 ms)
std dev              197.6 μs   (159.0 μs .. 254.8 μs)
variance introduced by outliers: 13% (moderately inflated)

benchmarking ParensSeq/ParensSeq/firstChild
time                 6.729 ms   (6.583 ms .. 6.930 ms)
                     0.997 R²   (0.995 R² .. 0.998 R²)
mean                 7.007 ms   (6.920 ms .. 7.110 ms)
std dev              273.1 μs   (222.3 μs .. 356.8 μs)
variance introduced by outliers: 18% (moderately inflated)

benchmarking ParensSeq/ParensSeq/nextSibling
time                 21.95 ms   (21.38 ms .. 22.60 ms)
                     0.997 R²   (0.994 R² .. 0.999 R²)
mean                 22.82 ms   (22.52 ms .. 23.15 ms)
std dev              745.8 μs   (575.3 μs .. 1.016 ms)

benchmarking ParensSeq/ParensSeq/(<|)
time                 35.50 μs   (35.18 μs .. 35.94 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 36.21 μs   (35.79 μs .. 36.68 μs)
std dev              1.517 μs   (1.248 μs .. 1.975 μs)
variance introduced by outliers: 47% (moderately inflated)

benchmarking ParensSeq/ParensSeq/(|>)
time                 35.93 μs   (35.59 μs .. 36.44 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 36.76 μs   (36.23 μs .. 37.46 μs)
std dev              2.136 μs   (1.560 μs .. 3.496 μs)
variance introduced by outliers: 64% (severely inflated)

benchmarking ParensSeq/ParensSeq/(<>)
time                 73.98 μs   (73.12 μs .. 75.02 μs)
                     0.998 R²   (0.998 R² .. 0.999 R²)
mean                 76.07 μs   (75.18 μs .. 77.24 μs)
std dev              3.540 μs   (3.000 μs .. 4.416 μs)
variance introduced by outliers: 50% (moderately inflated)

benchmarking ParensSeq/ParensSeq/fromWord64s
time                 35.12 μs   (34.66 μs .. 35.63 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 36.23 μs   (35.72 μs .. 36.84 μs)
std dev              1.781 μs   (1.552 μs .. 2.115 μs)
variance introduced by outliers: 55% (severely inflated)
```