### PR TITLE
Add carry argument to findUnmatchedCloseFar

### DIFF
--- a/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word16.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word16.hs
@@ -34,8 +34,8 @@ muk3 = 0x00ff
 -- This is the broadword implementation of 'HaskellWorks.Data.BalancedParens.Internal.Slow.Word16.findCloseFor'.
 --
 -- See [Broadword Implementation of Parenthesis Queries](https://arxiv.org/pdf/1301.5468.pdf), Sebastiano Vigna, 2013
-findUnmatchedCloseFar :: Word64 -> Word16 -> Word64
-findUnmatchedCloseFar p w =
+findUnmatchedCloseFar :: Word64 -> Word64 -> Word16 -> Word64
+findUnmatchedCloseFar c p w =
   --  Keys:
   --    * k1: Level of sub-words of size 2 = 1 .<. 1
   --    * k2: Level of sub-words of size 4 = 1 .<. 2
@@ -95,10 +95,11 @@ findUnmatchedCloseFar p w =
   let ok4  = ok4L + ok4R                                                                        in
   let ck4  =  (ck3 .&.  muk3) + kBitDiffPos 16 eck3 eok3                                        in
 
-  let pak4  = 0 :: Word64                                                                       in
-  let sak4  = 0 :: Word64                                                                       in
+  let pak4  = c                                                                                 in
+  let sak4  = 0                                                                                 in
 
-  let fk4   = (ck4 .>. fromIntegral sak4) .&. mask4                                             in
+  let hk4   = 0x0010 .&. comp (0xffff .>. fromIntegral sak4)                                    in
+  let fk4   = ((ck4 .>. fromIntegral sak4) .|. hk4) .&. mask4                                   in
   let bk4   = ((narrow pak4 - fk4) .>. fromIntegral (wsz - 1)) - 1                              in
   let mk4   = bk4 .&. mask4                                                                     in
   let pbk4  = pak4 - widen ((ck4 .>. fromIntegral sak4) .&. mk4)                                in
@@ -108,33 +109,33 @@ findUnmatchedCloseFar p w =
   let pak3  = pck4                                                                              in
   let sak3  = sbk4                                                                              in
 
-  let ek3   = 0x0808 .&. comp (0xffff .>. fromIntegral sak3)                                    in
-  let fk3   = ((ck3 .>. fromIntegral sak3) .|. ek3) .&. mask3                                   in
+  let hk3   = 0x0808 .&. comp (0xffff .>. fromIntegral sak3)                                    in
+  let fk3   = ((ck3 .>. fromIntegral sak3) .|. hk3) .&. mask3                                   in
   let bk3   = ((narrow pak3 - fk3) .>. fromIntegral (wsz - 1)) - 1                              in
   let mk3   = bk3 .&. mask3                                                                     in
-  let pbk3  = pak3 - widen (((ck3 .>. fromIntegral sak3) .|. ek3) .&. mk3)                      in
+  let pbk3  = pak3 - widen (((ck3 .>. fromIntegral sak3) .|. hk3) .&. mk3)                      in
   let pck3  = pbk3 + widen ( (ok3 .>. fromIntegral sak3)          .&. mk3)                      in
   let sbk3  = sak3 + widen (t8k3 .&. bk3)                                                       in
 
   let pak2  = pck3                                                                              in
   let sak2  = sbk3                                                                              in
 
-  let ek2   = 0xaaaa .&. comp (0xffff .>. fromIntegral sak2)                                    in
-  let fk2   = ((ck2 .>. fromIntegral sak2) .|. ek2) .&. mask2                                   in
+  let hk2   = 0x4444 .&. comp (0xffff .>. fromIntegral sak2)                                    in
+  let fk2   = ((ck2 .>. fromIntegral sak2) .|. hk2) .&. mask2                                   in
   let bk2   = ((narrow pak2 - fk2) .>. fromIntegral (wsz - 1)) - 1                              in
   let mk2   = bk2 .&. mask2                                                                     in
-  let pbk2  = pak2 - widen (((ck2 .>. fromIntegral sak2) .|. ek2) .&. mk2)                      in
+  let pbk2  = pak2 - widen (((ck2 .>. fromIntegral sak2) .|. hk2) .&. mk2)                      in
   let pck2  = pbk2 + widen ( (ok2 .>. fromIntegral sak2)          .&. mk2)                      in
   let sbk2  = sak2 + widen (t8k2 .&. bk2)                                                       in
 
   let pak1  = pck2                                                                              in
   let sak1  = sbk2                                                                              in
 
-  let ek1   = 0xaaaa .&. comp (0xffff .>. fromIntegral sak1)                                    in
-  let fk1   = ((ck1 .>. fromIntegral sak1) .|. ek1) .&. mask1                                   in
+  let hk1   = 0xaaaa .&. comp (0xffff .>. fromIntegral sak1)                                    in
+  let fk1   = ((ck1 .>. fromIntegral sak1) .|. hk1) .&. mask1                                   in
   let bk1   = ((narrow pak1 - fk1) .>. fromIntegral (wsz - 1)) - 1                              in
   let mk1   = bk1  .&. mask1                                                                    in
-  let pbk1  = pak1 - widen (((ck1 .>. fromIntegral sak1) .|. ek1) .&. mk1)                      in
+  let pbk1  = pak1 - widen (((ck1 .>. fromIntegral sak1) .|. hk1) .&. mk1)                      in
   let pck1  = pbk1 + widen ( (ok1 .>. fromIntegral sak1)          .&. mk1)                      in
   let sbk1  = sak1 + widen (t8k1 .&. bk1)                                                       in
 
@@ -153,6 +154,6 @@ findClose :: Word16 -> Count -> Maybe Count
 findClose v p = if p > 0
   then if closeAt v p
     then Just p
-    else let q = findUnmatchedCloseFar p v in Just (q + 1)
+    else let q = findUnmatchedCloseFar 0 p v in Just (q + 1)
   else Just 0
 {-# INLINE findClose #-}

--- a/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word32.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word32.hs
@@ -38,8 +38,8 @@ muk4 = 0x0000ffff
 -- This is the broadword implementation of 'HaskellWorks.Data.BalancedParens.Internal.Slow.Word32.findCloseFor'.
 --
 -- See [Broadword Implementation of Parenthesis Queries](https://arxiv.org/pdf/1301.5468.pdf), Sebastiano Vigna, 2013
-findUnmatchedCloseFar :: Word64 -> Word32 -> Word64
-findUnmatchedCloseFar p w =
+findUnmatchedCloseFar :: Word64 -> Word64 -> Word32 -> Word64
+findUnmatchedCloseFar c p w =
   --  Keys:
   --    * k1: Level of sub-words of size 2 = 1 .<. 1
   --    * k2: Level of sub-words of size 4 = 1 .<. 2
@@ -110,10 +110,11 @@ findUnmatchedCloseFar p w =
   let ok5  = ok5L + ok5R                                                                        in
   let ck5  =  (ck4 .&.  muk4) + kBitDiffPos 32 eck4 eok4                                        in
 
-  let pak5  = 0                                                                                 in
+  let pak5  = c                                                                                 in
   let sak5  = 0                                                                                 in
 
-  let fk5   = (ck5 .>. fromIntegral sak5) .&. mask5                                             in
+  let hk5   = 0x00200020 .&. comp (0xffffffff .>. fromIntegral sak5)                            in
+  let fk5   = ((ck5 .>. fromIntegral sak5) .|. hk5) .&. mask5                                   in
   let bk5   = ((narrow pak5 - fk5) .>. fromIntegral (wsz - 1)) - 1                              in
   let mk5   = bk5 .&. mask5                                                                     in
   let pbk5  = pak5 - widen ((ck5 .>. fromIntegral sak5) .&. mk5)                                in
@@ -123,44 +124,44 @@ findUnmatchedCloseFar p w =
   let pak4  = pck5                                                                              in
   let sak4  = sbk5                                                                              in
 
-  let ek4   = 0x00100010 .&. comp (0xffffffff .>. fromIntegral sak4)                            in
-  let fk4   = ((ck4 .>. fromIntegral sak4) .|. ek4) .&. mask4                                   in
+  let hk4   = 0x00100010 .&. comp (0xffffffff .>. fromIntegral sak4)                            in
+  let fk4   = ((ck4 .>. fromIntegral sak4) .|. hk4) .&. mask4                                   in
   let bk4   = ((narrow pak4 - fk4) .>. fromIntegral (wsz - 1)) - 1                              in
   let mk4   = bk4 .&. mask4                                                                     in
-  let pbk4  = pak4 - widen (((ck4 .>. fromIntegral sak4) .|. ek4) .&. mk4)                      in
+  let pbk4  = pak4 - widen (((ck4 .>. fromIntegral sak4) .|. hk4) .&. mk4)                      in
   let pck4  = pbk4 + widen ( (ok4 .>. fromIntegral sak4)          .&. mk4)                      in
   let sbk4  = sak4 + widen (t8k4 .&. bk4)                                                       in
 
   let pak3  = pck4                                                                              in
   let sak3  = sbk4                                                                              in
 
-  let ek3   = 0x08080808 .&. comp (0xffffffff .>. fromIntegral sak3)                            in
-  let fk3   = ((ck3 .>. fromIntegral sak3) .|. ek3) .&. mask3                                   in
+  let hk3   = 0x08080808 .&. comp (0xffffffff .>. fromIntegral sak3)                            in
+  let fk3   = ((ck3 .>. fromIntegral sak3) .|. hk3) .&. mask3                                   in
   let bk3   = ((narrow pak3 - fk3) .>. fromIntegral (wsz - 1)) - 1                              in
   let mk3   = bk3 .&. mask3                                                                     in
-  let pbk3  = pak3 - widen (((ck3 .>. fromIntegral sak3) .|. ek3) .&. mk3)                      in
+  let pbk3  = pak3 - widen (((ck3 .>. fromIntegral sak3) .|. hk3) .&. mk3)                      in
   let pck3  = pbk3 + widen ( (ok3 .>. fromIntegral sak3)          .&. mk3)                      in
   let sbk3  = sak3 + widen (t8k3 .&. bk3)                                                       in
 
   let pak2  = pck3                                                                              in
   let sak2  = sbk3                                                                              in
 
-  let ek2   = 0xaaaaaaaa .&. comp (0xffffffff .>. fromIntegral sak2)                            in
-  let fk2   = ((ck2 .>. fromIntegral sak2) .|. ek2) .&. mask2                                   in
+  let hk2   = 0x44444444 .&. comp (0xffffffff .>. fromIntegral sak2)                            in
+  let fk2   = ((ck2 .>. fromIntegral sak2) .|. hk2) .&. mask2                                   in
   let bk2   = ((narrow pak2 - fk2) .>. fromIntegral (wsz - 1)) - 1                              in
   let mk2   = bk2 .&. mask2                                                                     in
-  let pbk2  = pak2 - widen (((ck2 .>. fromIntegral sak2) .|. ek2) .&. mk2)                      in
+  let pbk2  = pak2 - widen (((ck2 .>. fromIntegral sak2) .|. hk2) .&. mk2)                      in
   let pck2  = pbk2 + widen ( (ok2 .>. fromIntegral sak2)          .&. mk2)                      in
   let sbk2  = sak2 + widen (t8k2 .&. bk2)                                                       in
 
   let pak1  = pck2                                                                              in
   let sak1  = sbk2                                                                              in
 
-  let ek1   = 0xaaaaaaaa .&. comp (0xffffffff .>. fromIntegral sak1)                            in
-  let fk1   = ((ck1 .>. fromIntegral sak1) .|. ek1) .&. mask1                                   in
+  let hk1   = 0xaaaaaaaa .&. comp (0xffffffff .>. fromIntegral sak1)                            in
+  let fk1   = ((ck1 .>. fromIntegral sak1) .|. hk1) .&. mask1                                   in
   let bk1   = ((narrow pak1 - fk1) .>. fromIntegral (wsz - 1)) - 1                              in
   let mk1   = bk1  .&. mask1                                                                    in
-  let pbk1  = pak1 - widen (((ck1 .>. fromIntegral sak1) .|. ek1) .&. mk1)                      in
+  let pbk1  = pak1 - widen (((ck1 .>. fromIntegral sak1) .|. hk1) .&. mk1)                      in
   let pck1  = pbk1 + widen ( (ok1 .>. fromIntegral sak1)          .&. mk1)                      in
   let sbk1  = sak1 + widen (t8k1 .&. bk1)                                                       in
 
@@ -179,6 +180,6 @@ findClose :: Word32 -> Count -> Maybe Count
 findClose v p = if p > 0
   then if closeAt v p
     then Just p
-    else let q = findUnmatchedCloseFar p v in Just (q + 1)
+    else let q = findUnmatchedCloseFar 0 p v in Just (q + 1)
   else Just 0
 {-# INLINE findClose #-}

--- a/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word64.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word64.hs
@@ -40,8 +40,8 @@ muk5 = 0x00000000ffffffff
 -- This is the broadword implementation of 'HaskellWorks.Data.BalancedParens.Internal.Slow.Word64.findCloseFor'.
 --
 -- See [Broadword Implementation of Parenthesis Queries](https://arxiv.org/pdf/1301.5468.pdf), Sebastiano Vigna, 2013
-findUnmatchedCloseFar :: Word64 -> Word64 -> Word64
-findUnmatchedCloseFar p w =
+findUnmatchedCloseFar :: Word64 -> Word64 -> Word64 -> Word64
+findUnmatchedCloseFar c p w =
   --  Keys:
   --    * k1: Level of sub-words of size 2 = 1 .<. 1
   --    * k2: Level of sub-words of size 4 = 1 .<. 2
@@ -123,10 +123,11 @@ findUnmatchedCloseFar p w =
   let ok6  = ok6L + ok6R                                                                  in
   let ck6  =  (ck5 .&.  muk5) + kBitDiffPos 32 eck5 eok5                                  in
 
-  let qak6  = 0                                                                           in
+  let qak6  = c                                                                           in
   let sak6  = 0                                                                           in
 
-  let fk6   = (ck6 .>. fromIntegral sak6) .&. mask6                                       in
+  let hk6   = 0x0000004000000040 .&. comp (0xffffffffffffffff .>. fromIntegral sak6)      in
+  let fk6   = ((ck6 .>. fromIntegral sak6) .|. hk6) .&. mask6                             in
   let bk6   = ((qak6 - fk6) .>. fromIntegral (wsz - 1)) - 1                               in
   let mk6   = bk6 .&. mask6                                                               in
   let pbk6  = qak6 - ((ck6 .>. fromIntegral sak6) .&. mk6)                                in
@@ -136,55 +137,55 @@ findUnmatchedCloseFar p w =
   let qak5  = pck6                                                                        in
   let sak5  = sbk6                                                                        in
 
-  let ek5   = 0x0000002000000020 .&. comp (0xffffffffffffffff .>. fromIntegral sak5)      in
-  let fk5   = ((ck5 .>. fromIntegral sak5) .|. ek5) .&. mask5                             in
+  let hk5   = 0x0000002000000020 .&. comp (0xffffffffffffffff .>. fromIntegral sak5)      in
+  let fk5   = ((ck5 .>. fromIntegral sak5) .|. hk5) .&. mask5                             in
   let bk5   = ((qak5 - fk5) .>. fromIntegral (wsz - 1)) - 1                               in
   let mk5   = bk5 .&. mask5                                                               in
-  let pbk5  = qak5 - (((ck5 .>. fromIntegral sak5) .|. ek5) .&. mk5)                      in
+  let pbk5  = qak5 - (((ck5 .>. fromIntegral sak5) .|. hk5) .&. mk5)                      in
   let pck5  = pbk5 + ( (ok5 .>. fromIntegral sak5)          .&. mk5)                      in
   let sbk5  = sak5 + (t8k5 .&. bk5)                                                       in
 
   let qak4  = pck5                                                                        in
   let sak4  = sbk5                                                                        in
 
-  let ek4   = 0x0010001000100010 .&. comp (0xffffffffffffffff .>. fromIntegral sak4)      in
-  let fk4   = ((ck4 .>. fromIntegral sak4) .|. ek4) .&. mask4                             in
+  let hk4   = 0x0010001000100010 .&. comp (0xffffffffffffffff .>. fromIntegral sak4)      in
+  let fk4   = ((ck4 .>. fromIntegral sak4) .|. hk4) .&. mask4                             in
   let bk4   = ((qak4 - fk4) .>. fromIntegral (wsz - 1)) - 1                               in
   let mk4   = bk4 .&. mask4                                                               in
-  let pbk4  = qak4 - (((ck4 .>. fromIntegral sak4) .|. ek4) .&. mk4)                      in
+  let pbk4  = qak4 - (((ck4 .>. fromIntegral sak4) .|. hk4) .&. mk4)                      in
   let pck4  = pbk4 + ( (ok4 .>. fromIntegral sak4)          .&. mk4)                      in
   let sbk4  = sak4 + (t8k4 .&. bk4)                                                       in
 
   let qak3  = pck4                                                                        in
   let sak3  = sbk4                                                                        in
 
-  let ek3   = 0x0808080808080808 .&. comp (0xffffffffffffffff .>. fromIntegral sak3)      in
-  let fk3   = ((ck3 .>. fromIntegral sak3) .|. ek3) .&. mask3                             in
+  let hk3   = 0x0808080808080808 .&. comp (0xffffffffffffffff .>. fromIntegral sak3)      in
+  let fk3   = ((ck3 .>. fromIntegral sak3) .|. hk3) .&. mask3                             in
   let bk3   = ((qak3 - fk3) .>. fromIntegral (wsz - 1)) - 1                               in
   let mk3   = bk3 .&. mask3                                                               in
-  let pbk3  = qak3 - (((ck3 .>. fromIntegral sak3) .|. ek3) .&. mk3)                      in
+  let pbk3  = qak3 - (((ck3 .>. fromIntegral sak3) .|. hk3) .&. mk3)                      in
   let pck3  = pbk3 + ( (ok3 .>. fromIntegral sak3)          .&. mk3)                      in
   let sbk3  = sak3 + (t8k3 .&. bk3)                                                       in
 
   let qak2  = pck3                                                                        in
   let sak2  = sbk3                                                                        in
 
-  let ek2   = 0xaaaaaaaaaaaaaaaa .&. comp (0xffffffffffffffff .>. fromIntegral sak2)      in
-  let fk2   = ((ck2 .>. fromIntegral sak2) .|. ek2) .&. mask2                             in
+  let hk2   = 0x4444444444444444 .&. comp (0xffffffffffffffff .>. fromIntegral sak2)      in
+  let fk2   = ((ck2 .>. fromIntegral sak2) .|. hk2) .&. mask2                             in
   let bk2   = ((qak2 - fk2) .>. fromIntegral (wsz - 1)) - 1                               in
   let mk2   = bk2 .&. mask2                                                               in
-  let pbk2  = qak2 - (((ck2 .>. fromIntegral sak2) .|. ek2) .&. mk2)                      in
+  let pbk2  = qak2 - (((ck2 .>. fromIntegral sak2) .|. hk2) .&. mk2)                      in
   let pck2  = pbk2 + ( (ok2 .>. fromIntegral sak2)          .&. mk2)                      in
   let sbk2  = sak2 + (t8k2 .&. bk2)                                                       in
 
   let qak1  = pck2                                                                        in
   let sak1  = sbk2                                                                        in
 
-  let ek1   = 0xaaaaaaaaaaaaaaaa .&. comp (0xffffffffffffffff .>. fromIntegral sak1)      in
-  let fk1   = ((ck1 .>. fromIntegral sak1) .|. ek1) .&. mask1                             in
+  let hk1   = 0xaaaaaaaaaaaaaaaa .&. comp (0xffffffffffffffff .>. fromIntegral sak1)      in
+  let fk1   = ((ck1 .>. fromIntegral sak1) .|. hk1) .&. mask1                             in
   let bk1   = ((qak1 - fk1) .>. fromIntegral (wsz - 1)) - 1                               in
   let mk1   = bk1  .&. mask1                                                              in
-  let pbk1  = qak1 - (((ck1 .>. fromIntegral sak1) .|. ek1) .&. mk1)                      in
+  let pbk1  = qak1 - (((ck1 .>. fromIntegral sak1) .|. hk1) .&. mk1)                      in
   let pck1  = pbk1 + ( (ok1 .>. fromIntegral sak1)          .&. mk1)                      in
   let sbk1  = sak1 + (t8k1 .&. bk1)                                                       in
 
@@ -203,6 +204,6 @@ findClose :: Word64 -> Count -> Maybe Count
 findClose v p = if p > 0
   then if closeAt v p
     then Just p
-    else let q = findUnmatchedCloseFar p v in Just (q + 1)
+    else let q = findUnmatchedCloseFar 0 p v in Just (q + 1)
   else Just 0
 {-# INLINE findClose #-}

--- a/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word8.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word8.hs
@@ -30,8 +30,8 @@ muk2 = 0x0f
 -- This is the broadword implementation of 'HaskellWorks.Data.BalancedParens.Internal.Slow.Word8.findCloseFor'.
 --
 -- See [Broadword Implementation of Parenthesis Queries](https://arxiv.org/pdf/1301.5468.pdf), Sebastiano Vigna, 2013
-findUnmatchedCloseFar :: Word64 -> Word8 -> Word64
-findUnmatchedCloseFar p w =
+findUnmatchedCloseFar :: Word64 -> Word64 -> Word8 -> Word64
+findUnmatchedCloseFar c p w =
   --  Keys:
   --    * k1: Level of sub-words of size 2 = 1 .<. 1
   --    * k2: Level of sub-words of size 4 = 1 .<. 2
@@ -45,6 +45,7 @@ findUnmatchedCloseFar p w =
   --    * m: deficit at position sub-word mask
   --    * pa: position accumulator
   --    * sa: shift accumulator
+  --    * h: high sub-block close parens count
   --    * f: far sub-block close parens count
   let x     = w .>. p                                                                           in
   let wsz   = 8 :: Int8                                                                         in
@@ -66,49 +67,50 @@ findUnmatchedCloseFar p w =
   let ok1   = ( (b0  .&. b1  )           .<. 1) .|. ll                                          in
   let ck1   = (((b0  .|. b1  ) .^. 0x55) .<. 1) .|. ll                                          in
 
-  let eok1 =   ok1 .&.  muk1                                                                    in
-  let eck1 =  (ck1 .&. (muk1 .<. t64k1)) .>. t64k1                                              in
-  let ok2L =  (ok1 .&. (muk1 .<. t64k1)) .>. t64k1                                              in
-  let ok2R = kBitDiffPos 4 eok1 eck1                                                            in
-  let ok2  = ok2L + ok2R                                                                        in
-  let ck2  =  (ck1 .&.  muk1) + kBitDiffPos 4 eck1 eok1                                         in
+  let eok1  =   ok1 .&.  muk1                                                                   in
+  let eck1  =  (ck1 .&. (muk1 .<. t64k1)) .>. t64k1                                             in
+  let ok2L  =  (ok1 .&. (muk1 .<. t64k1)) .>. t64k1                                             in
+  let ok2R  = kBitDiffPos 4 eok1 eck1                                                           in
+  let ok2   = ok2L + ok2R                                                                       in
+  let ck2   =  (ck1 .&.  muk1) + kBitDiffPos 4 eck1 eok1                                        in
 
-  let eok2 =   ok2 .&.  muk2                                                                    in
-  let eck2 =  (ck2 .&. (muk2 .<. t64k2)) .>. t64k2                                              in
-  let ok3L =  (ok2 .&. (muk2 .<. t64k2)) .>. t64k2                                              in
-  let ok3R = kBitDiffPos 8 eok2 eck2                                                            in
-  let ok3  = ok3L + ok3R                                                                        in
-  let ck3  =  (ck2 .&.  muk2) + kBitDiffPos 8 eck2 eok2                                         in
+  let eok2  =   ok2 .&.  muk2                                                                   in
+  let eck2  =  (ck2 .&. (muk2 .<. t64k2)) .>. t64k2                                             in
+  let ok3L  =  (ok2 .&. (muk2 .<. t64k2)) .>. t64k2                                             in
+  let ok3R  = kBitDiffPos 8 eok2 eck2                                                           in
+  let ok3   = ok3L + ok3R                                                                       in
+  let ck3   =  (ck2 .&.  muk2) + kBitDiffPos 8 eck2 eok2                                        in
 
-  let pak3  = 0                                                                                 in
+  let pak3  = c                                                                                 in
   let sak3  = 0                                                                                 in
 
-  let fk3   = (ck3 .>. fromIntegral sak3) .&. mask3                                             in
+  let hk3   = 0x08 .&. comp (0xff .>. fromIntegral sak3)                                        in
+  let fk3   = (ck3 .>. fromIntegral sak3 .|. hk3) .&. mask3                                     in
   let bk3   = ((narrow pak3 - fk3) .>. fromIntegral (wsz - 1)) - 1                              in
   let mk3   = bk3 .&. mask3                                                                     in
-  let pbk3  = pak3 - widen ((ck3 .>. fromIntegral sak3) .&. mk3)                                in
-  let pck3  = pbk3 + widen ((ok3 .>. fromIntegral sak3) .&. mk3)                                in
+  let pbk3  = pak3 - widen (((ck3 .>. fromIntegral sak3) .|. hk3) .&. mk3)                      in
+  let pck3  = pbk3 + widen (((ok3 .>. fromIntegral sak3) .|. hk3) .&. mk3)                      in
   let sbk3  = sak3 + widen (t8k3 .&. bk3)                                                       in
 
   let pak2  = pck3                                                                              in
   let sak2  = sbk3                                                                              in
 
-  let ek2   = 0xaa .&. comp (0xff .>. fromIntegral sak2)                                        in
-  let fk2   = ((ck2 .>. fromIntegral sak2) .|. ek2) .&. mask2                                   in
+  let hk2   = 0x44 .&. comp (0xff .>. fromIntegral sak2)                                        in
+  let fk2   = ((ck2 .>. fromIntegral sak2) .|. hk2) .&. mask2                                   in
   let bk2   = ((narrow pak2 - fk2) .>. fromIntegral (wsz - 1)) - 1                              in
   let mk2   = bk2 .&. mask2                                                                     in
-  let pbk2  = pak2 - widen (((ck2 .>. fromIntegral sak2) .|. ek2) .&. mk2)                      in
+  let pbk2  = pak2 - widen (((ck2 .>. fromIntegral sak2) .|. hk2) .&. mk2)                      in
   let pck2  = pbk2 + widen ( (ok2 .>. fromIntegral sak2)          .&. mk2)                      in
   let sbk2  = sak2 + widen (t8k2 .&. bk2)                                                       in
 
   let pak1  = pck2                                                                              in
   let sak1  = sbk2                                                                              in
 
-  let ek1   = 0xaa .&. comp (0xff .>. fromIntegral sak1)                                        in
-  let fk1   = ((ck1 .>. fromIntegral sak1) .|. ek1) .&. mask1                                   in
+  let hk1   = 0xaa .&. comp (0xff .>. fromIntegral sak1)                                        in
+  let fk1   = ((ck1 .>. fromIntegral sak1) .|. hk1) .&. mask1                                   in
   let bk1   = ((narrow pak1 - fk1) .>. fromIntegral (wsz - 1)) - 1                              in
   let mk1   = bk1  .&. mask1                                                                    in
-  let pbk1  = pak1 - widen (((ck1 .>. fromIntegral sak1) .|. ek1) .&. mk1)                      in
+  let pbk1  = pak1 - widen (((ck1 .>. fromIntegral sak1) .|. hk1) .&. mk1)                      in
   let pck1  = pbk1 + widen ( (ok1 .>. fromIntegral sak1)          .&. mk1)                      in
   let sbk1  = sak1 + widen (t8k1 .&. bk1)                                                       in
 
@@ -157,6 +159,6 @@ findClose :: Word8 -> Count -> Maybe Count
 findClose v p = if p > 0
   then if closeAt v p
     then Just p
-    else let q = findUnmatchedCloseFar p v in Just (q + 1)
+    else let q = findUnmatchedCloseFar 0 p v in Just (q + 1)
   else Just 0
 {-# INLINE findClose #-}

--- a/src/HaskellWorks/Data/BalancedParens/Internal/Slow/FindUnmatchedCloseFar/Word16.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Slow/FindUnmatchedCloseFar/Word16.hs
@@ -19,57 +19,57 @@ import HaskellWorks.Data.Bits.BitWise
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string:
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "00000000 00000000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "00000000 00000000"
 -- 0
 --
 -- The following scans for the first unmatched closing parenthesis after skipping one bit from the beginning of the
 -- bit string:
 --
--- >>> findUnmatchedCloseFar 1 $ fromJust $ bitRead "00000000 00000000"
+-- >>> findUnmatchedCloseFar 0 1 $ fromJust $ bitRead "00000000 00000000"
 -- 1
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string.  To find
 -- unmatched parenthesis, the scan passes over the first parent of matching parentheses:
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "10000000 00000000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "10000000 00000000"
 -- 2
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string, but runs
 -- out of bits.  The scan continues as if there an inifinite string of zero bits follows, the first of which is at
 -- position 64, which also happens to be the position of the unmatched parenthesis.
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "11111111 00000000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "11111111 00000000"
 -- 16
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string, but runs
 -- out of bits.  The scan continues as if there an inifinite string of zero bits follows and we don't get to the
 -- unmatched parenthesis until position 128.
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "11111111 11111111"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "11111111 11111111"
 -- 32
 --
 -- Following are some more examples:
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "11110000 11110000"
 -- 16
--- >>> findUnmatchedCloseFar 1 $ fromJust $ bitRead "11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 1 $ fromJust $ bitRead "11110000 11110000"
 -- 7
--- >>> findUnmatchedCloseFar 2 $ fromJust $ bitRead "11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 2 $ fromJust $ bitRead "11110000 11110000"
 -- 6
--- >>> findUnmatchedCloseFar 3 $ fromJust $ bitRead "11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 3 $ fromJust $ bitRead "11110000 11110000"
 -- 5
--- >>> findUnmatchedCloseFar 4 $ fromJust $ bitRead "11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 4 $ fromJust $ bitRead "11110000 11110000"
 -- 4
--- >>> findUnmatchedCloseFar 5 $ fromJust $ bitRead "11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 5 $ fromJust $ bitRead "11110000 11110000"
 -- 5
--- >>> findUnmatchedCloseFar 6 $ fromJust $ bitRead "11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 6 $ fromJust $ bitRead "11110000 11110000"
 -- 6
--- >>> findUnmatchedCloseFar 7 $ fromJust $ bitRead "11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 7 $ fromJust $ bitRead "11110000 11110000"
 -- 7
--- >>> findUnmatchedCloseFar 8 $ fromJust $ bitRead "11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 8 $ fromJust $ bitRead "11110000 11110000"
 -- 16
-findUnmatchedCloseFar :: Word64 -> Word16 -> Word64
-findUnmatchedCloseFar = go 0
+findUnmatchedCloseFar :: Word64 -> Word64 -> Word16 -> Word64
+findUnmatchedCloseFar = go
   where go :: Word64 -> Word64 -> Word16 -> Word64
         go d 16 _ = 16 + d
         go d i w = case (w .>. i) .&. 1 of

--- a/src/HaskellWorks/Data/BalancedParens/Internal/Slow/FindUnmatchedCloseFar/Word32.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Slow/FindUnmatchedCloseFar/Word32.hs
@@ -19,57 +19,57 @@ import HaskellWorks.Data.Bits.BitWise
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string:
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "00000000 00000000 00000000 00000000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "00000000 00000000 00000000 00000000"
 -- 0
 --
 -- The following scans for the first unmatched closing parenthesis after skipping one bit from the beginning of the
 -- bit string:
 --
--- >>> findUnmatchedCloseFar 1 $ fromJust $ bitRead "00000000 00000000 00000000 00000000"
+-- >>> findUnmatchedCloseFar 0 1 $ fromJust $ bitRead "00000000 00000000 00000000 00000000"
 -- 1
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string.  To find
 -- unmatched parenthesis, the scan passes over the first parent of matching parentheses:
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "10000000 00000000 00000000 00000000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "10000000 00000000 00000000 00000000"
 -- 2
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string, but runs
 -- out of bits.  The scan continues as if there an inifinite string of zero bits follows, the first of which is at
 -- position 64, which also happens to be the position of the unmatched parenthesis.
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "11111111 11111111 00000000 00000000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "11111111 11111111 00000000 00000000"
 -- 32
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string, but runs
 -- out of bits.  The scan continues as if there an inifinite string of zero bits follows and we don't get to the
 -- unmatched parenthesis until position 128.
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "11111111 11111111 11111111 11111111"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "11111111 11111111 11111111 11111111"
 -- 64
 --
 -- Following are some more examples:
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
 -- 32
--- >>> findUnmatchedCloseFar 1 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 1 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
 -- 7
--- >>> findUnmatchedCloseFar 2 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 2 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
 -- 6
--- >>> findUnmatchedCloseFar 3 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 3 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
 -- 5
--- >>> findUnmatchedCloseFar 4 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 4 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
 -- 4
--- >>> findUnmatchedCloseFar 5 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 5 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
 -- 5
--- >>> findUnmatchedCloseFar 6 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 6 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
 -- 6
--- >>> findUnmatchedCloseFar 7 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 7 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
 -- 7
--- >>> findUnmatchedCloseFar 8 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 8 $ fromJust $ bitRead "11110000 11110000 11110000 11110000"
 -- 32
-findUnmatchedCloseFar :: Word64 -> Word32 -> Word64
-findUnmatchedCloseFar = go 0
+findUnmatchedCloseFar :: Word64 -> Word64 -> Word32 -> Word64
+findUnmatchedCloseFar = go
   where go :: Word64 -> Word64 -> Word32 -> Word64
         go d 32 _ = 32 + d
         go d i w = case (w .>. i) .&. 1 of

--- a/src/HaskellWorks/Data/BalancedParens/Internal/Slow/FindUnmatchedCloseFar/Word64.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Slow/FindUnmatchedCloseFar/Word64.hs
@@ -19,57 +19,57 @@ import HaskellWorks.Data.Bits.BitWise
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string:
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000"
 -- 0
 --
 -- The following scans for the first unmatched closing parenthesis after skipping one bit from the beginning of the
 -- bit string:
 --
--- >>> findUnmatchedCloseFar 1 $ fromJust $ bitRead "00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000"
+-- >>> findUnmatchedCloseFar 0 1 $ fromJust $ bitRead "00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000"
 -- 1
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string.  To find
 -- unmatched parenthesis, the scan passes over the first parent of matching parentheses:
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "10000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "10000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000"
 -- 2
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string, but runs
 -- out of bits.  The scan continues as if there an inifinite string of zero bits follows, the first of which is at
 -- position 64, which also happens to be the position of the unmatched parenthesis.
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "11111111 11111111 11111111 11111111 00000000 00000000 00000000 00000000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "11111111 11111111 11111111 11111111 00000000 00000000 00000000 00000000"
 -- 64
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string, but runs
 -- out of bits.  The scan continues as if there an inifinite string of zero bits follows and we don't get to the
 -- unmatched parenthesis until position 128.
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "11111111 11111111 11111111 11111111 11111111 11111111 11111111 11111111"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "11111111 11111111 11111111 11111111 11111111 11111111 11111111 11111111"
 -- 128
 --
 -- Following are some more examples:
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
 -- 64
--- >>> findUnmatchedCloseFar 1 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 1 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
 -- 7
--- >>> findUnmatchedCloseFar 2 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 2 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
 -- 6
--- >>> findUnmatchedCloseFar 3 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 3 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
 -- 5
--- >>> findUnmatchedCloseFar 4 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 4 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
 -- 4
--- >>> findUnmatchedCloseFar 5 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 5 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
 -- 5
--- >>> findUnmatchedCloseFar 6 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 6 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
 -- 6
--- >>> findUnmatchedCloseFar 7 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 7 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
 -- 7
--- >>> findUnmatchedCloseFar 8 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
+-- >>> findUnmatchedCloseFar 0 8 $ fromJust $ bitRead "11110000 11110000 11110000 11110000 11110000 11110000 11110000 11110000"
 -- 64
-findUnmatchedCloseFar :: Word64 -> Word64 -> Word64
-findUnmatchedCloseFar = go 0
+findUnmatchedCloseFar :: Word64 -> Word64 -> Word64 -> Word64
+findUnmatchedCloseFar = go
   where go :: Word64 -> Word64 -> Word64 -> Word64
         go d 64 _ = 64 + d
         go d i w = case (w .>. fromIntegral i) .&. 1 of

--- a/src/HaskellWorks/Data/BalancedParens/Internal/Slow/FindUnmatchedCloseFar/Word8.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Slow/FindUnmatchedCloseFar/Word8.hs
@@ -19,57 +19,57 @@ import HaskellWorks.Data.Bits.BitWise
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string:
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "00000000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "00000000"
 -- 0
 --
 -- The following scans for the first unmatched closing parenthesis after skipping one bit from the beginning of the
 -- bit string:
 --
--- >>> findUnmatchedCloseFar 1 $ fromJust $ bitRead "00000000"
+-- >>> findUnmatchedCloseFar 0 1 $ fromJust $ bitRead "00000000"
 -- 1
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string.  To find
 -- unmatched parenthesis, the scan passes over the first parent of matching parentheses:
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "10000000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "10000000"
 -- 2
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string, but runs
 -- out of bits.  The scan continues as if there an inifinite string of zero bits follows, the first of which is at
 -- position 64, which also happens to be the position of the unmatched parenthesis.
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "11110000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "11110000"
 -- 8
 --
 -- The following scans for the first unmatched closing parenthesis from the beginning of the bit string, but runs
 -- out of bits.  The scan continues as if there an inifinite string of zero bits follows and we don't get to the
 -- unmatched parenthesis until position 128.
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "11111111"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "11111111"
 -- 16
 --
 -- Following are some more examples:
 --
--- >>> findUnmatchedCloseFar 0 $ fromJust $ bitRead "11110000"
+-- >>> findUnmatchedCloseFar 0 0 $ fromJust $ bitRead "11110000"
 -- 8
--- >>> findUnmatchedCloseFar 1 $ fromJust $ bitRead "11110000"
+-- >>> findUnmatchedCloseFar 0 1 $ fromJust $ bitRead "11110000"
 -- 7
--- >>> findUnmatchedCloseFar 2 $ fromJust $ bitRead "11110000"
+-- >>> findUnmatchedCloseFar 0 2 $ fromJust $ bitRead "11110000"
 -- 6
--- >>> findUnmatchedCloseFar 3 $ fromJust $ bitRead "11110000"
+-- >>> findUnmatchedCloseFar 0 3 $ fromJust $ bitRead "11110000"
 -- 5
--- >>> findUnmatchedCloseFar 4 $ fromJust $ bitRead "11110000"
+-- >>> findUnmatchedCloseFar 0 4 $ fromJust $ bitRead "11110000"
 -- 4
--- >>> findUnmatchedCloseFar 5 $ fromJust $ bitRead "11110000"
+-- >>> findUnmatchedCloseFar 0 5 $ fromJust $ bitRead "11110000"
 -- 5
--- >>> findUnmatchedCloseFar 6 $ fromJust $ bitRead "11110000"
+-- >>> findUnmatchedCloseFar 0 6 $ fromJust $ bitRead "11110000"
 -- 6
--- >>> findUnmatchedCloseFar 7 $ fromJust $ bitRead "11110000"
+-- >>> findUnmatchedCloseFar 0 7 $ fromJust $ bitRead "11110000"
 -- 7
--- >>> findUnmatchedCloseFar 8 $ fromJust $ bitRead "11110000"
+-- >>> findUnmatchedCloseFar 0 8 $ fromJust $ bitRead "11110000"
 -- 8
-findUnmatchedCloseFar :: Word64 -> Word8 -> Word64
-findUnmatchedCloseFar = go 0
+findUnmatchedCloseFar :: Word64 -> Word64 -> Word8 -> Word64
+findUnmatchedCloseFar = go
   where go :: Word64 -> Word64 -> Word8 -> Word64
         go d 8 _ = 8 + d
         go d i w = case (w .>. i) .&. 1 of

--- a/test/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word16Spec.hs
+++ b/test/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word16Spec.hs
@@ -27,13 +27,13 @@ spec = describe "HaskellWorks.Data.BalancedParens.Broadword.Word16Spec" $ do
     w <- forAll $ pure $ fromJust $ bitRead "11111111 11110100"
     annotateShow $ bitShow w
     annotateShow $ showHex w ""
-    BW16.findUnmatchedCloseFar p w === SW16.findUnmatchedCloseFar p w
-
-  it "findUnmatchedCloseFar" $ require $ withTests 1000 $ property $ do
+    BW16.findUnmatchedCloseFar 0 p w === SW16.findUnmatchedCloseFar 0 p w
+  it "findUnmatchedCloseFar" $ require $ withTests 2000 $ property $ do
+    c <- forAll $ G.word64 (R.linear 0 64)
     p <- forAll $ G.word64 (R.linear 0 16)
     w <- forAll $ G.word16 R.constantBounded
     annotateShow $ bitShow w
-    BW16.findUnmatchedCloseFar p w === SW16.findUnmatchedCloseFar p w
+    BW16.findUnmatchedCloseFar c p w === SW16.findUnmatchedCloseFar c p w
   it "findClose" $ require $ withTests 1000 $ property $ do
     p <- forAll $ G.word64 (R.linear 1 128)
     w <- forAll $ G.word16 R.constantBounded

--- a/test/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word32Spec.hs
+++ b/test/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word32Spec.hs
@@ -23,12 +23,13 @@ spec = describe "HaskellWorks.Data.BalancedParens.Broadword.Word32Spec" $ do
     p <- forAll $ pure 0
     w <- forAll $ pure 0xe9f6e7ff
     annotateShow $ bitShow w
-    BW32.findUnmatchedCloseFar p w === SW32.findUnmatchedCloseFar p w
-  it "findUnmatchedCloseFar" $ require $ withTests 10000 $ property $ do
+    BW32.findUnmatchedCloseFar 0 p w === SW32.findUnmatchedCloseFar 0 p w
+  it "findUnmatchedCloseFar" $ require $ withTests 40000 $ property $ do
+    c <- forAll $ G.word64 (R.linear 0 64)
     p <- forAll $ G.word64 (R.linear 0 32)
     w <- forAll $ G.word32 R.constantBounded
     annotateShow $ bitShow w
-    BW32.findUnmatchedCloseFar p w === SW32.findUnmatchedCloseFar p w
+    BW32.findUnmatchedCloseFar c p w === SW32.findUnmatchedCloseFar c p w
   it "findClose" $ require $ withTests 1000 $ property $ do
     p <- forAll $ G.word64 (R.linear 1 128)
     w <- forAll $ G.word32 R.constantBounded

--- a/test/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word64Spec.hs
+++ b/test/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word64Spec.hs
@@ -21,10 +21,11 @@ import qualified Hedgehog.Range                                                 
 spec :: Spec
 spec = describe "HaskellWorks.Data.BalancedParens.Broadword.Word64Spec" $ do
   it "findUnmatchedCloseFar" $ require $ withTests 100000 $ property $ do
-    p <- forAll $ G.word64 (R.linear 0 64)
+    c <- forAll $ G.word64 (R.linear 0 128)
+    p <- forAll $ G.word64 (R.linear 0 128)
     w <- forAll $ G.word64 R.constantBounded
     annotateShow $ bitShow w
-    BW64.findUnmatchedCloseFar p w === SW64.findUnmatchedCloseFar p w
+    BW64.findUnmatchedCloseFar c p w === SW64.findUnmatchedCloseFar c p w
   it "findClose" $ require $ withTests 1000 $ property $ do
     p <- forAll $ G.word64 (R.linear 1 128)
     w <- forAll $ G.word64 R.constantBounded

--- a/test/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word8Spec.hs
+++ b/test/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindUnmatchedCloseFar/Word8Spec.hs
@@ -3,7 +3,6 @@
 
 module HaskellWorks.Data.BalancedParens.Internal.Broadword.FindUnmatchedCloseFar.Word8Spec where
 
-import Control.Monad                  (forM_)
 import HaskellWorks.Data.Bits.BitShow
 import HaskellWorks.Hspec.Hedgehog
 import Hedgehog
@@ -20,13 +19,12 @@ import qualified Hedgehog.Range                                                 
 
 spec :: Spec
 spec = describe "HaskellWorks.Data.BalancedParens.Broadword.Word8Spec" $ do
-  describe "findUnmatchedCloseFar" $ do
-    forM_ [0 .. 8] $ \p0 -> do
-      forM_ [0 .. 0xff] $ \w0 -> do
-        it ("word " <> bitShow w0) $ requireTest $ do
-          p <- forAll $ pure p0
-          w <- forAll $ pure w0
-          BW8.findUnmatchedCloseFar p w === SW8.findUnmatchedCloseFar p w
+  it "findUnmatchedCloseFar" $ require $ withTests 1000 $ property $ do
+    c <- forAll $ G.word64 (R.linear 0 64)
+    p <- forAll $ G.word64 (R.linear 0 8)
+    w <- forAll $ G.word8 R.constantBounded
+    annotateShow $ bitShow w
+    BW8.findUnmatchedCloseFar c p w === SW8.findUnmatchedCloseFar c p w
   it "findClose" $ require $ withTests 1000 $ property $ do
     p <- forAll $ G.word64 (R.linear 1 128)
     w <- forAll $ G.word8 R.constantBounded


### PR DESCRIPTION
The additional carry argument allows `findUnmatchedCloseFar` calls to be composed to handler longer bit-strings than the word size allows.

Adding the extra argument exposed a latent bug in the code that was inaccessible to property testing previously because the software fault can only be triggered by a non-zero carry argument.

The bug was already evident in code because there ought to be a pattern in the constants used.

Namely `0xaaaaaaaaaaaaaaaa`, `0x4444444444444444`, `0x0808080808080808`, `0x0010001000100010`, `0x0000002000000020`, and `0x0000004000000040`.

The fact the original code didn't conform to this pattern should have been a give away there is a latent bug waiting to be found.