### PR TITLE
Benchmarks for broadword implementation of findClose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ cabal.sandbox.config
 /stack-ci.yaml
 /.ghc.environment.*
 /cabal.project.local
-
+/data

--- a/hw-balancedparens.cabal
+++ b/hw-balancedparens.cabal
@@ -25,6 +25,7 @@ common base                       { build-depends: base                       >=
 common bytestring                 { build-depends: bytestring                 >= 0.9        && < 0.11   }
 common criterion                  { build-depends: criterion                  >= 1.2        && < 1.6    }
 common deepseq                    { build-depends: deepseq                    >= 1.4.2.0    && < 1.5    }
+common directory                  { build-depends: directory                  >= 1.2.2      && < 1.4    }
 common doctest                    { build-depends: doctest                    >= 0.16.2     && < 0.17   }
 common doctest-discover           { build-depends: doctest-discover           >= 0.2        && < 0.3    }
 common generic-lens               { build-depends: generic-lens               >= 1.2.0.0    && < 2.1    }
@@ -178,10 +179,14 @@ test-suite hw-balancedparens-test
 benchmark bench
   import:               base, config
                       , criterion
+                      , deepseq
+                      , directory
+                      , generic-lens
                       , hedgehog
                       , hw-balancedparens
                       , hw-bits
                       , hw-prim
+                      , lens
                       , vector
   other-modules:        HaskellWorks.Data.BalancedParens.Gen
   type:                 exitcode-stdio-1.0

--- a/project.sh
+++ b/project.sh
@@ -17,6 +17,7 @@ cabal-install() {
 
 cabal-build() {
   cabal v2-build \
+    --enable-benchmarks \
     --enable-tests \
     --write-ghc-environment-files=ghc8.4.4+ \
     $CABAL_FLAGS "$@"


### PR DESCRIPTION
```
benchmarking Loading lazy byte string into Word64s/BWV64.findClose with sum data/bench/vector-08k.ib.idx
time                 7.833 ms   (7.357 ms .. 8.225 ms)
                     0.972 R²   (0.917 R² .. 0.995 R²)
mean                 8.686 ms   (8.413 ms .. 9.349 ms)
std dev              1.292 ms   (426.7 μs .. 2.361 ms)
variance introduced by outliers: 75% (severely inflated)

benchmarking Loading lazy byte string into Word64s/CLS.findClose   with sum data/bench/vector-08k.ib.idx
time                 9.402 ms   (9.290 ms .. 9.571 ms)
                     0.998 R²   (0.995 R² .. 0.999 R²)
mean                 9.456 ms   (9.351 ms .. 9.573 ms)
std dev              315.2 μs   (232.1 μs .. 414.0 μs)
variance introduced by outliers: 12% (moderately inflated)

benchmarking Loading lazy byte string into Word64s/BWV64.findClose with sum data/bench/vector-16k.ib.idx
time                 14.37 ms   (14.18 ms .. 14.53 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 14.42 ms   (14.28 ms .. 14.59 ms)
std dev              389.3 μs   (305.5 μs .. 502.4 μs)

benchmarking Loading lazy byte string into Word64s/CLS.findClose   with sum data/bench/vector-16k.ib.idx
time                 19.57 ms   (19.19 ms .. 19.95 ms)
                     0.998 R²   (0.997 R² .. 1.000 R²)
mean                 19.58 ms   (19.42 ms .. 19.82 ms)
std dev              427.9 μs   (281.4 μs .. 630.1 μs)

benchmarking Loading lazy byte string into Word64s/BWV64.findClose with sum data/bench/vector-24k.ib.idx
time                 27.97 ms   (27.57 ms .. 28.31 ms)
                     0.998 R²   (0.995 R² .. 1.000 R²)
mean                 27.88 ms   (27.59 ms .. 28.38 ms)
std dev              807.6 μs   (461.4 μs .. 1.329 ms)

benchmarking Loading lazy byte string into Word64s/CLS.findClose   with sum data/bench/vector-24k.ib.idx
time                 29.75 ms   (29.14 ms .. 30.30 ms)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 30.11 ms   (29.61 ms .. 31.70 ms)
std dev              1.705 ms   (737.9 μs .. 3.126 ms)
variance introduced by outliers: 17% (moderately inflated)

benchmarking Loading lazy byte string into Word64s/BWV64.findClose with sum data/bench/vector-32k.ib.idx
time                 54.21 ms   (53.57 ms .. 54.93 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 54.12 ms   (53.65 ms .. 54.83 ms)
std dev              1.059 ms   (587.7 μs .. 1.693 ms)

benchmarking Loading lazy byte string into Word64s/CLS.findClose   with sum data/bench/vector-32k.ib.idx
time                 40.32 ms   (39.31 ms .. 41.11 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 40.20 ms   (39.82 ms .. 40.59 ms)
std dev              776.6 μs   (565.8 μs .. 1.052 ms)

benchmarking Loading lazy byte string into Word64s/BWV64.findClose with sum data/bench/vector-40k.ib.idx
time                 81.62 ms   (80.24 ms .. 82.69 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 83.00 ms   (82.20 ms .. 84.85 ms)
std dev              2.028 ms   (925.1 μs .. 3.255 ms)

benchmarking Loading lazy byte string into Word64s/CLS.findClose   with sum data/bench/vector-40k.ib.idx
time                 50.68 ms   (49.59 ms .. 51.98 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 50.43 ms   (49.97 ms .. 51.00 ms)
std dev              981.7 μs   (752.8 μs .. 1.367 ms)

benchmarking Loading lazy byte string into Word64s/BWV64.findClose with sum data/bench/vector-48k.ib.idx
time                 122.0 ms   (114.6 ms .. 125.1 ms)
                     0.998 R²   (0.994 R² .. 1.000 R²)
mean                 123.5 ms   (121.5 ms .. 126.8 ms)
std dev              4.084 ms   (2.343 ms .. 6.318 ms)
variance introduced by outliers: 11% (moderately inflated)

benchmarking Loading lazy byte string into Word64s/CLS.findClose   with sum data/bench/vector-48k.ib.idx
time                 60.70 ms   (60.34 ms .. 61.25 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 60.62 ms   (60.23 ms .. 61.00 ms)
std dev              678.9 μs   (454.8 μs .. 936.5 μs)

benchmarking Loading lazy byte string into Word64s/BWV64.findClose with sum data/bench/vector-62k.ib.idx
time                 183.5 ms   (179.8 ms .. 188.9 ms)
                     1.000 R²   (0.998 R² .. 1.000 R²)
mean                 183.1 ms   (181.9 ms .. 185.4 ms)
std dev              2.148 ms   (853.4 μs .. 3.047 ms)
variance introduced by outliers: 14% (moderately inflated)

benchmarking Loading lazy byte string into Word64s/CLS.findClose   with sum data/bench/vector-62k.ib.idx
time                 79.40 ms   (77.93 ms .. 80.95 ms)
                     0.999 R²   (0.996 R² .. 1.000 R²)
mean                 79.70 ms   (78.69 ms .. 80.61 ms)
std dev              1.668 ms   (1.143 ms .. 2.260 ms)
```