### PR TITLE
Re-implement findClose in terms of findUnmatchedCloseFar

### DIFF
--- a/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindClose/Vector16.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindClose/Vector16.hs
@@ -2,45 +2,53 @@ module HaskellWorks.Data.BalancedParens.Internal.Broadword.FindClose.Vector16
   ( findClose
   ) where
 
-import Data.Int
 import Data.Word
-import HaskellWorks.Data.AtIndex
 import HaskellWorks.Data.BalancedParens.CloseAt
-import HaskellWorks.Data.Bits.BitLength
-import HaskellWorks.Data.Int.Unsigned
 import HaskellWorks.Data.Positioning
 
-import qualified Data.Vector.Storable                                                             as DVS
-import qualified HaskellWorks.Data.BalancedParens.Internal.Broadword.FindUnmatchedCloseFar.Word16 as BW16
-import qualified HaskellWorks.Data.Drop                                                           as HW
-import qualified HaskellWorks.Data.Length                                                         as HW
+import qualified Data.Vector.Storable                                                               as DVS
+import qualified HaskellWorks.Data.BalancedParens.Internal.Broadword.FindUnmatchedCloseFar.Vector16 as BWV16
 
-findCloseCont :: DVS.Vector Word16 -> Int64 -> Count -> Maybe Count
-findCloseCont v i c = if i < HW.end v
-  then case BW16.findUnmatchedCloseFar c 0 w of
-    q -> if q >= bitLength w
-      then findCloseCont v (i + 1) (q - bitLength w)
-      else Just (b + q + 1)
-  else Just (b + c + 1)
-  where b  = unsigned i * bitLength w -- base
-        w  = v !!! fromIntegral i
-{-# INLINE findCloseCont #-}
-
+-- | Find the position of the matching close parenthesis.
+--
+-- The position argument and return value is one-based.
+--
+-- If the parenthesis at the input position is an a close, then that is considered the
+-- matching close parenthesis.
+--
+-- >>> import HaskellWorks.Data.Bits.BitRead
+-- >>> import Data.Maybe
+--
+-- The following scans for the matching close parenthesis for the open parenthesis at position 1:
+--
+-- >>> findClose (fromJust $ bitRead "10000000") 1
+-- Just 2
+--
+-- >>> findClose (fromJust $ bitRead "11000000") 1
+-- Just 4
+--
+-- >>> findClose (fromJust $ bitRead "11010000") 1
+-- Just 6
+--
+-- The following scans for the matching close parenthesis for the open parenthesis at position 2:
+--
+-- >>> findClose (fromJust $ bitRead "11010000") 2
+-- Just 3
+--
+-- If the input position has a close parenthesis, then that position is returned:
+--
+-- >>> findClose (fromJust $ bitRead "11010000") 3
+-- Just 3
+--
+-- The scan can continue past the end of the input word because every bit after then end of the
+-- word is considered to be zero, which is a closing parenthesis:
+--
+-- >>> findClose (fromJust $ bitRead "11111110") 1
+-- Just 14
 findClose :: DVS.Vector Word16 -> Count -> Maybe Count
-findClose _ 0 = Nothing
-findClose v p = fmap (+ vd) (findClose' (HW.drop vi v) (p - vd))
-  where vi = (p - 1) `div` elemBitLength v
-        vd = vi * elemBitLength v
+findClose v p = if p > 0
+  then if closeAt v p
+    then Just p
+    else Just (BWV16.findUnmatchedCloseFar 0 p v + 1)
+  else Just (BWV16.findUnmatchedCloseFar 1 p v)
 {-# INLINE findClose #-}
-
-findClose' :: DVS.Vector Word16 -> Count -> Maybe Count
-findClose' v p = if DVS.length v > 0
-    then if closeAt w p
-      then Just p
-      else case BW16.findUnmatchedCloseFar 0 p w of
-        q -> if q >= bitLength w
-          then  findCloseCont v 1 (q - bitLength w)
-          else Just (q + 1)
-    else Just (p * 2)
-  where w  = v !!! 0
-{-# INLINE findClose' #-}

--- a/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindClose/Vector32.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindClose/Vector32.hs
@@ -2,45 +2,53 @@ module HaskellWorks.Data.BalancedParens.Internal.Broadword.FindClose.Vector32
   ( findClose
   ) where
 
-import Data.Int
 import Data.Word
-import HaskellWorks.Data.AtIndex
 import HaskellWorks.Data.BalancedParens.CloseAt
-import HaskellWorks.Data.Bits.BitLength
-import HaskellWorks.Data.Int.Unsigned
 import HaskellWorks.Data.Positioning
 
-import qualified Data.Vector.Storable                                                             as DVS
-import qualified HaskellWorks.Data.BalancedParens.Internal.Broadword.FindUnmatchedCloseFar.Word32 as BW32
-import qualified HaskellWorks.Data.Drop                                                           as HW
-import qualified HaskellWorks.Data.Length                                                         as HW
+import qualified Data.Vector.Storable                                                               as DVS
+import qualified HaskellWorks.Data.BalancedParens.Internal.Broadword.FindUnmatchedCloseFar.Vector32 as BWV32
 
-findCloseCont :: DVS.Vector Word32 -> Int64 -> Count -> Maybe Count
-findCloseCont v i c = if i < HW.end v
-  then case BW32.findUnmatchedCloseFar c 0 w of
-    q -> if q >= bitLength w
-      then findCloseCont v (i + 1) (q - bitLength w)
-      else Just (b + q + 1)
-  else Just (b + c + 1)
-  where b  = unsigned i * bitLength w -- base
-        w  = v !!! fromIntegral i
-{-# INLINE findCloseCont #-}
-
+-- | Find the position of the matching close parenthesis.
+--
+-- The position argument and return value is one-based.
+--
+-- If the parenthesis at the input position is an a close, then that is considered the
+-- matching close parenthesis.
+--
+-- >>> import HaskellWorks.Data.Bits.BitRead
+-- >>> import Data.Maybe
+--
+-- The following scans for the matching close parenthesis for the open parenthesis at position 1:
+--
+-- >>> findClose (fromJust $ bitRead "10000000") 1
+-- Just 2
+--
+-- >>> findClose (fromJust $ bitRead "11000000") 1
+-- Just 4
+--
+-- >>> findClose (fromJust $ bitRead "11010000") 1
+-- Just 6
+--
+-- The following scans for the matching close parenthesis for the open parenthesis at position 2:
+--
+-- >>> findClose (fromJust $ bitRead "11010000") 2
+-- Just 3
+--
+-- If the input position has a close parenthesis, then that position is returned:
+--
+-- >>> findClose (fromJust $ bitRead "11010000") 3
+-- Just 3
+--
+-- The scan can continue past the end of the input word because every bit after then end of the
+-- word is considered to be zero, which is a closing parenthesis:
+--
+-- >>> findClose (fromJust $ bitRead "11111110") 1
+-- Just 14
 findClose :: DVS.Vector Word32 -> Count -> Maybe Count
-findClose _ 0 = Nothing
-findClose v p = fmap (+ vd) (findClose' (HW.drop vi v) (p - vd))
-  where vi = (p - 1) `div` elemBitLength v
-        vd = vi * elemBitLength v
+findClose v p = if p > 0
+  then if closeAt v p
+    then Just p
+    else Just (BWV32.findUnmatchedCloseFar 0 p v + 1)
+  else Just (BWV32.findUnmatchedCloseFar 1 p v)
 {-# INLINE findClose #-}
-
-findClose' :: DVS.Vector Word32 -> Count -> Maybe Count
-findClose' v p = if DVS.length v > 0
-    then if closeAt w p
-      then Just p
-      else case BW32.findUnmatchedCloseFar 0 p w of
-        q -> if q >= bitLength w
-          then  findCloseCont v 1 (q - bitLength w)
-          else Just (q + 1)
-    else Just (p * 2)
-  where w  = v !!! 0
-{-# INLINE findClose' #-}

--- a/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindClose/Vector8.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindClose/Vector8.hs
@@ -2,45 +2,53 @@ module HaskellWorks.Data.BalancedParens.Internal.Broadword.FindClose.Vector8
   ( findClose
   ) where
 
-import Data.Int
 import Data.Word
-import HaskellWorks.Data.AtIndex
 import HaskellWorks.Data.BalancedParens.CloseAt
-import HaskellWorks.Data.Bits.BitLength
-import HaskellWorks.Data.Int.Unsigned
 import HaskellWorks.Data.Positioning
 
-import qualified Data.Vector.Storable                                                            as DVS
-import qualified HaskellWorks.Data.BalancedParens.Internal.Broadword.FindUnmatchedCloseFar.Word8 as BW32
-import qualified HaskellWorks.Data.Drop                                                          as HW
-import qualified HaskellWorks.Data.Length                                                        as HW
+import qualified Data.Vector.Storable                                                              as DVS
+import qualified HaskellWorks.Data.BalancedParens.Internal.Broadword.FindUnmatchedCloseFar.Vector8 as BWV8
 
-findCloseCont :: DVS.Vector Word8 -> Int64 -> Count -> Maybe Count
-findCloseCont v i c = if i < HW.end v
-  then case BW32.findUnmatchedCloseFar c 0 w of
-    q -> if q >= bitLength w
-      then findCloseCont v (i + 1) (q - bitLength w)
-      else Just (b + q + 1)
-  else Just (b + c + 1)
-  where b  = unsigned i * bitLength w -- base
-        w  = v !!! fromIntegral i
-{-# INLINE findCloseCont #-}
-
+-- | Find the position of the matching close parenthesis.
+--
+-- The position argument and return value is one-based.
+--
+-- If the parenthesis at the input position is an a close, then that is considered the
+-- matching close parenthesis.
+--
+-- >>> import HaskellWorks.Data.Bits.BitRead
+-- >>> import Data.Maybe
+--
+-- The following scans for the matching close parenthesis for the open parenthesis at position 1:
+--
+-- >>> findClose (fromJust $ bitRead "10000000") 1
+-- Just 2
+--
+-- >>> findClose (fromJust $ bitRead "11000000") 1
+-- Just 4
+--
+-- >>> findClose (fromJust $ bitRead "11010000") 1
+-- Just 6
+--
+-- The following scans for the matching close parenthesis for the open parenthesis at position 2:
+--
+-- >>> findClose (fromJust $ bitRead "11010000") 2
+-- Just 3
+--
+-- If the input position has a close parenthesis, then that position is returned:
+--
+-- >>> findClose (fromJust $ bitRead "11010000") 3
+-- Just 3
+--
+-- The scan can continue past the end of the input word because every bit after then end of the
+-- word is considered to be zero, which is a closing parenthesis:
+--
+-- >>> findClose (fromJust $ bitRead "11111110") 1
+-- Just 14
 findClose :: DVS.Vector Word8 -> Count -> Maybe Count
-findClose _ 0 = Nothing
-findClose v p = fmap (+ vd) (findClose' (HW.drop vi v) (p - vd))
-  where vi = (p - 1) `div` elemBitLength v
-        vd = vi * elemBitLength v
+findClose v p = if p > 0
+  then if closeAt v p
+    then Just p
+    else Just (BWV8.findUnmatchedCloseFar 0 p v + 1)
+  else Just (BWV8.findUnmatchedCloseFar 1 p v)
 {-# INLINE findClose #-}
-
-findClose' :: DVS.Vector Word8 -> Count -> Maybe Count
-findClose' v p = if DVS.length v > 0
-    then if closeAt w p
-      then Just p
-      else case BW32.findUnmatchedCloseFar 0 p w of
-        q -> if q >= bitLength w
-          then  findCloseCont v 1 (q - bitLength w)
-          else Just (q + 1)
-    else Just (p * 2)
-  where w  = v !!! 0
-{-# INLINE findClose' #-}

--- a/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindClose/Word16.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindClose/Word16.hs
@@ -48,6 +48,6 @@ findClose :: Word16 -> Count -> Maybe Count
 findClose v p = if p > 0
   then if closeAt v p
     then Just p
-    else let q = W16.findUnmatchedCloseFar 0 p v in Just (q + 1)
+    else Just (W16.findUnmatchedCloseFar 0 p v + 1)
   else Just (W16.findUnmatchedCloseFar 1 p v)
 {-# INLINE findClose #-}

--- a/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindClose/Word32.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindClose/Word32.hs
@@ -48,6 +48,6 @@ findClose :: Word32 -> Count -> Maybe Count
 findClose v p = if p > 0
   then if closeAt v p
     then Just p
-    else let q = W32.findUnmatchedCloseFar 0 p v in Just (q + 1)
+    else Just (W32.findUnmatchedCloseFar 0 p v + 1)
   else Just (W32.findUnmatchedCloseFar 1 p v)
 {-# INLINE findClose #-}

--- a/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindClose/Word64.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindClose/Word64.hs
@@ -48,6 +48,6 @@ findClose :: Word64 -> Count -> Maybe Count
 findClose v p = if p > 0
   then if closeAt v p
     then Just p
-    else let q = W64.findUnmatchedCloseFar 0 p v in Just (q + 1)
+    else Just (W64.findUnmatchedCloseFar 0 p v + 1)
   else Just (W64.findUnmatchedCloseFar 1 p v)
 {-# INLINE findClose #-}

--- a/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindClose/Word8.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/Broadword/FindClose/Word8.hs
@@ -48,6 +48,6 @@ findClose :: Word8 -> Count -> Maybe Count
 findClose v p = if p > 0
   then if closeAt v p
     then Just p
-    else let q = W8.findUnmatchedCloseFar 0 p v in Just (q + 1)
+    else Just (W8.findUnmatchedCloseFar 0 p v + 1)
   else Just (W8.findUnmatchedCloseFar 1 p v)
 {-# INLINE findClose #-}


### PR DESCRIPTION
For a small, but respectable performance gain.

Before:

```
benchmarking Vector/FindClose 2-bit/Broadword
time                 19.30 ns   (19.05 ns .. 19.65 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 19.28 ns   (19.14 ns .. 19.46 ns)
std dev              537.2 ps   (387.1 ps .. 688.1 ps)
variance introduced by outliers: 45% (moderately inflated)

benchmarking Vector/FindClose 4-bit/Broadword
time                 19.51 ns   (19.15 ns .. 20.05 ns)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 19.62 ns   (19.39 ns .. 19.99 ns)
std dev              983.9 ps   (661.5 ps .. 1.325 ns)
variance introduced by outliers: 73% (severely inflated)

benchmarking Vector/FindClose 8-bit/Broadword
time                 19.28 ns   (19.16 ns .. 19.39 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 19.23 ns   (19.15 ns .. 19.36 ns)
std dev              334.4 ps   (251.4 ps .. 467.0 ps)
variance introduced by outliers: 24% (moderately inflated)

benchmarking Vector/FindClose 16-bit/Broadword
time                 19.32 ns   (19.24 ns .. 19.40 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 19.27 ns   (19.22 ns .. 19.33 ns)
std dev              196.4 ps   (136.6 ps .. 262.5 ps)
variance introduced by outliers: 10% (moderately inflated)

benchmarking Vector/FindClose 32-bit/Broadword
time                 19.27 ns   (19.20 ns .. 19.34 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 19.23 ns   (19.15 ns .. 19.31 ns)
std dev              262.3 ps   (229.0 ps .. 312.0 ps)
variance introduced by outliers: 17% (moderately inflated)
```

After:

```
benchmarking Vector/FindClose 2-bit/Broadword
time                 18.77 ns   (18.63 ns .. 18.91 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 18.68 ns   (18.61 ns .. 18.76 ns)
std dev              262.2 ps   (207.4 ps .. 317.9 ps)
variance introduced by outliers: 17% (moderately inflated)

benchmarking Vector/FindClose 4-bit/Broadword
time                 18.56 ns   (18.50 ns .. 18.63 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 18.57 ns   (18.52 ns .. 18.66 ns)
std dev              210.0 ps   (131.2 ps .. 392.3 ps)
variance introduced by outliers: 12% (moderately inflated)

benchmarking Vector/FindClose 8-bit/Broadword
time                 18.61 ns   (18.54 ns .. 18.68 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 18.64 ns   (18.59 ns .. 18.71 ns)
std dev              192.5 ps   (142.2 ps .. 261.8 ps)
variance introduced by outliers: 10% (moderately inflated)

benchmarking Vector/FindClose 16-bit/Broadword
time                 18.67 ns   (18.57 ns .. 18.77 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 18.64 ns   (18.59 ns .. 18.70 ns)
std dev              177.3 ps   (142.8 ps .. 235.6 ps)

benchmarking Vector/FindClose 32-bit/Broadword
time                 18.61 ns   (18.55 ns .. 18.68 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 18.65 ns   (18.58 ns .. 18.75 ns)
std dev              255.7 ps   (174.0 ps .. 382.0 ps)
variance introduced by outliers: 17% (moderately inflated)

benchmarking Vector/FindClose 64-bit/Broadword
time                 18.61 ns   (18.53 ns .. 18.79 ns)
                     0.999 R²   (0.995 R² .. 1.000 R²)
mean                 18.77 ns   (18.59 ns .. 19.42 ns)
std dev              1.049 ns   (188.6 ps .. 2.175 ns)
variance introduced by outliers: 77% (severely inflated)
```