### PR TITLE
GHC 9.4 compatibility

### DIFF
--- a/src/HaskellWorks/Data/BalancedParens/Internal/ParensSeq.hs
+++ b/src/HaskellWorks/Data/BalancedParens/Internal/ParensSeq.hs
@@ -123,7 +123,7 @@ ftSplit p ft = case FT.viewl rt of
           else 0
 
 atSizeBelowZero :: Count -> Measure -> Bool
-atSizeBelowZero n m = n < size (m :: Measure)
+atSizeBelowZero n (Measure { size = sz }) = n < sz
 
 atMinZero :: Measure -> Bool
-atMinZero m = min (m :: Measure) <= 0
+atMinZero (Measure { min = m }) = m <= 0

--- a/src/HaskellWorks/Data/BalancedParens/ParensSeq.hs
+++ b/src/HaskellWorks/Data/BalancedParens/ParensSeq.hs
@@ -30,6 +30,7 @@ import Prelude                                             hiding (drop, max, mi
 
 import qualified Data.List                                           as L
 import qualified HaskellWorks.Data.BalancedParens.Internal.ParensSeq as PS
+  hiding ( Elem(size) )
 import qualified HaskellWorks.Data.BalancedParens.Internal.Word      as W
 import qualified HaskellWorks.Data.FingerTree                        as FT
 


### PR DESCRIPTION
This fixes ambiguity of record field selectors, due to GHC 9.4 no longer using a type-directed disambiguation mechanism for bare record field selectors. With this patch, I'm able to compile `hw-balancedparens` with GHC 9.4.3.